### PR TITLE
Add new Header navigation

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -114,7 +114,6 @@ export const Footer = ({ className, fullWidth }: FooterProps) => {
                       ? `${getLink('source', 'common').url}/commit/${GIT_COMMIT_SHA}`
                       : `${getLink('source', 'common').url}/commits`
                   }
-                  underline
                 >
                   {formatDate(BUILD_DATE)}
                 </Link>

--- a/components/Header/Header.animations.ts
+++ b/components/Header/Header.animations.ts
@@ -13,7 +13,7 @@ import {
 
 /**
  * Note that these enter/exit animations rely heavily on the mask animation, so
- * if you add too much delay things may not work well, so keep them in sync.
+ * if you add too much delay things may not work well. Keep these in sync.
  */
 export const enterExitBtnTextIfNavOpen: AnimationProps = {
   exit: {
@@ -120,16 +120,16 @@ export const maskNavVariant: Variants = {
 };
 
 export const maskNavItemVariant: Variants = {
-  closed: {
+  closed: ({ y = '11rem' } = {}) => ({
     opacity: 0,
     transition: TRANS_PRIMARY_FAST,
-    y: 88,
-  },
-  initial: {
+    y,
+  }),
+  initial: ({ y = '11rem' } = {}) => ({
     opacity: 0,
     transition: TRANS_PRIMARY_FAST,
-    y: 88,
-  },
+    y,
+  }),
   open: {
     opacity: 1,
     transition: TRANS_PRIMARY_FAST,

--- a/components/Header/Header.scss
+++ b/components/Header/Header.scss
@@ -222,6 +222,10 @@
     pointer-events: none;
   }
 
+  .Header.is-animating:not(.has-scrollbar) & {
+    --scrollbar-overflow: hidden;
+  }
+
   &:before {
     background: linear-gradient(var(--bg-950) 50%, transparent);
     content: '';

--- a/components/Header/Header.scss
+++ b/components/Header/Header.scss
@@ -208,6 +208,7 @@
   color: var(--text-50);
   display: none;
   flex-direction: column;
+  gap: rem($space-l);
   inset: 0;
   min-width: var(--root-min-width);
   position: fixed;
@@ -239,7 +240,7 @@
 
 .Header-mask-nav {
   flex: 1;
-  margin-top: calc(var(--Header-height) + #{rem($space-l)});
+  padding-top: calc(var(--Header-height) + #{rem($space-l)});
   width: 100%;
   z-index: 0;
 
@@ -395,7 +396,7 @@
   align-items: flex-end;
   color: var(--text-100);
   display: flex;
-  margin: rem($space-l) 0 rem($space-m) 0;
+  margin-bottom: rem($space-m);
 
   @include mq(m) {
     margin-bottom: rem($space-xl);

--- a/components/Header/Header.scss
+++ b/components/Header/Header.scss
@@ -223,32 +223,25 @@
   }
 
   &:before {
-    background: linear-gradient(var(--bg-950) 40%, transparent);
+    background: linear-gradient(var(--bg-950) 50%, transparent);
     content: '';
-    height: rem($space * 8);
-    left: 0;
+    height: calc(var(--Header-height) + #{rem($space-l)});
+    inset: 0 0 auto 0;
     pointer-events: none;
     position: fixed;
-    right: 0;
     z-index: 1;
-
-    @include mq(m) {
-      height: rem($space * 8);
-    }
-
-    @include mq(l) {
-      height: rem($space * 11);
-    }
   }
 }
 
 .Header-mask-nav {
-  margin: max(16.5vh, #{rem($space * 7)}) auto auto;
+  flex: 1;
+  margin-top: calc(var(--Header-height) + #{rem($space-l)});
   width: 100%;
   z-index: 0;
 
   @include mq(m) {
-    margin-top: max(25vh, #{rem($space * 9)});
+    align-items: center;
+    display: grid;
   }
 }
 
@@ -258,47 +251,13 @@
   transition: border-radius var(--trans-primary-fastest);
   z-index: 1;
 
-  &:last-child {
-    .Header-mask-nav-link {
-      &:before,
-      &:after {
-        border: 0;
-      }
-    }
-  }
-
   @include mq(m) {
-    @for $i from 2 through 4 {
+    @for $i from 2 through 5 {
       &:nth-child(#{$i}) {
         .Header-mask-nav-link {
           &:before {
             flex-basis: calc((var(--wrap-space-left) + #{rem($space)}) * #{$i});
           }
-        }
-      }
-    }
-
-    @for $i from 5 through 6 {
-      &:nth-child(#{$i}) {
-        .Header-mask-nav-link {
-          &:before {
-            flex: 1;
-          }
-
-          &:after {
-            flex: 0;
-            flex-basis: calc(
-              (var(--wrap-space-left) + #{rem($space * 4)}) * #{$i - 4}
-            );
-          }
-        }
-
-        .Header-mask-nav-link-inner {
-          flex-direction: row-reverse;
-        }
-
-        .Header-mask-nav-link-eye {
-          margin-right: rem($space);
         }
       }
     }
@@ -411,46 +370,45 @@
   }
 }
 
-.Header-footer {
-  display: flex;
-  margin: max(7.5vh, #{rem($space-l)}) 0 rem($space-ml) 0;
+.Header-mask-nav-secondary-item {
+  --heading: var(--text-100);
 
-  @include mq($until: m) {
-    @include text(s);
+  &:not(:last-child) {
+    margin-bottom: rem($space-2xs + $space-4xs);
   }
+
+  .Header-mask-nav-item + & {
+    margin-top: rem($space-m);
+  }
+}
+
+/* =======================================
+ * Footer
+ * ======================================= */
+
+.Header-footer {
+  --link: var(--text-100);
+  align-items: flex-end;
+  color: var(--text-100);
+  display: flex;
+  margin: rem($space-l) 0 rem($space-m) 0;
 
   @include mq(m) {
     margin-bottom: rem($space-xl);
   }
-
-  @include mq(l) {
-    margin-bottom: rem($space-2xl);
-  }
 }
 
-.Header-footer-links {
-  display: flex;
-  flex-direction: column;
-  gap: rem($space-xs);
-
-  @include mq(l) {
-    gap: rem($space-4xs);
-  }
+.Header-footer-nav {
+  --link: var(--text-50);
 }
 
 .Header-footer-right {
-  display: flex;
-  flex-direction: column;
-  margin-left: auto;
-  text-align: right;
-
   @include mq(m) {
-    .Header-footer-links {
-      display: none;
-    }
+    align-items: flex-end;
+    display: flex;
+    flex-direction: column;
+    gap: rem($space-m);
+    margin-left: auto;
+    text-align: right;
   }
-}
-
-.Header-footer-copyright {
-  margin: auto 0 0 0;
 }

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,13 +1,15 @@
 import { AnimatePresence, m, useAnimation } from 'framer-motion';
+import { BUILD_DATE, CONTENT, GIT_COMMIT_SHA, MQ, SITEMAP } from '@/lib/config';
 import { ButtonArrow } from '@/components/Button';
-import { CONTENT, LINKS, MQ, SITEMAP } from '@/lib/config';
 import { debounce } from 'lodash-es';
 import {
   enterExitBtnArrow,
   enterExitBtnArrowIfNavOpen,
   enterExitBtnText,
   enterExitBtnTextIfNavOpen,
+  HeaderFooterNavItem,
   HeaderMaskNavItem,
+  HeaderMaskNavItemSecondary,
   HeaderNavItem,
   type HeaderProps,
   mainItemInVariant,
@@ -18,10 +20,12 @@ import {
   maskNavVariant,
   maskOpenTransition,
 } from './';
-import { getLink } from '@/lib/utils';
+import { formatDate, getLink } from '@/lib/utils';
 import { Link } from '@/components/Link';
 import { type LinkEvent } from '@/types';
 import { LinkRoll } from '@/components/LinkRoll';
+import { SomeIcons } from '@/components/SomeIcons';
+import { Text } from '@/components/Text';
 import { urlState } from '@/lib/useUrlState';
 import { useApp } from '@/components/App';
 import { useCallbackRef } from 'use-callback-ref';
@@ -34,8 +38,6 @@ import { useMedia } from 'react-use';
 import { useRouter } from 'next/router';
 import c from 'clsx';
 import FocusTrap from 'focus-trap-react';
-
-const source = getLink('source', 'common');
 
 export const Header = ({ navTitle = CONTENT.defaultNavTitle }: HeaderProps) => {
   const router = useRouter();
@@ -416,7 +418,7 @@ export const Header = ({ navTitle = CONTENT.defaultNavTitle }: HeaderProps) => {
               >
                 <ul>
                   {SITEMAP.project
-                    .filter(item => !item.hidden)
+                    .filter(item => !item.hidden && item.id != 'home')
                     .map(item => {
                       return (
                         <HeaderMaskNavItem
@@ -429,6 +431,18 @@ export const Header = ({ navTitle = CONTENT.defaultNavTitle }: HeaderProps) => {
                         />
                       );
                     })}
+                  {SITEMAP.common
+                    .filter(item => item.id != 'home')
+                    .map(item => {
+                      return (
+                        <HeaderMaskNavItemSecondary
+                          href={item.url}
+                          key={item.id}
+                          onClick={handleLinkClick}
+                          title={item.navTitle}
+                        />
+                      );
+                    })}
                 </ul>
               </m.nav>
               <m.footer
@@ -436,34 +450,38 @@ export const Header = ({ navTitle = CONTENT.defaultNavTitle }: HeaderProps) => {
                 className="Header-footer wrap"
                 variants={maskNavItemVariant}
               >
-                <ul className="Header-footer-links">
-                  {LINKS.social.map(link => {
-                    return (
-                      <li key={link.id}>
-                        <Link href={link.url}>{link.title}</Link>
-                      </li>
-                    );
-                  })}
-                </ul>
+                <Text className="Header-footer-nav visible@m" size="l" tag="ul">
+                  {SITEMAP.common
+                    .filter(item => item.id != 'home')
+                    .map(item => {
+                      return (
+                        <HeaderFooterNavItem
+                          href={item.url}
+                          key={item.id}
+                          onClick={handleLinkClick}
+                          title={item.navTitle}
+                        />
+                      );
+                    })}
+                </Text>
                 <div className="Header-footer-right">
-                  <ul className="Header-footer-links">
-                    {SITEMAP.common
-                      .filter(item => !item.hidden)
-                      .map(item => {
-                        return (
-                          <li key={item.id}>
-                            <Link href={item.url} templateTransition={false}>
-                              {item.navTitle}
-                            </Link>
-                          </li>
-                        );
-                      })}
-                  </ul>
-                  <p className="Header-footer-copyright">
-                    &copy; {new Date().getFullYear()} <br />
-                    Joonas Sandell <br />
-                    <Link href={`${source.url}`}>{source.title}</Link>
-                  </p>
+                  <SomeIcons />
+                  <Text className="visible@m mb:0" size="s" tag="p">
+                    Last updated:{' '}
+                    <Link
+                      href={
+                        GIT_COMMIT_SHA
+                          ? `${getLink('source', 'common').url}/commit/${GIT_COMMIT_SHA}`
+                          : `${getLink('source', 'common').url}/commits`
+                      }
+                    >
+                      {formatDate(BUILD_DATE)}
+                    </Link>
+                    {' ✳︎ '}
+                    <Link href={getLink('source', 'common').url}>
+                      {getLink('source', 'common').title}
+                    </Link>
+                  </Text>
                 </div>
               </m.footer>
             </>

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -431,18 +431,20 @@ export const Header = ({ navTitle = CONTENT.defaultNavTitle }: HeaderProps) => {
                         />
                       );
                     })}
-                  {SITEMAP.common
-                    .filter(item => item.id != 'home')
-                    .map(item => {
-                      return (
-                        <HeaderMaskNavItemSecondary
-                          href={item.url}
-                          key={item.id}
-                          onClick={handleLinkClick}
-                          title={item.navTitle}
-                        />
-                      );
-                    })}
+                  {!mqM &&
+                    SITEMAP.common
+                      .filter(item => item.id != 'home')
+                      .map(item => {
+                        return (
+                          <HeaderMaskNavItemSecondary
+                            custom={{ y: '5rem' }}
+                            href={item.url}
+                            key={item.id}
+                            onClick={handleLinkClick}
+                            title={item.navTitle}
+                          />
+                        );
+                      })}
                 </ul>
               </m.nav>
               <m.footer

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -20,7 +20,7 @@ import {
   maskNavVariant,
   maskOpenTransition,
 } from './';
-import { formatDate, getLink } from '@/lib/utils';
+import { formatDate, getLink, hasScrollbar, isBrowser } from '@/lib/utils';
 import { Link } from '@/components/Link';
 import { type LinkEvent } from '@/types';
 import { LinkRoll } from '@/components/LinkRoll';
@@ -57,6 +57,8 @@ export const Header = ({ navTitle = CONTENT.defaultNavTitle }: HeaderProps) => {
   const [mask, setMask] = useState('closedReset');
   const maskRef = useRef<HTMLDivElement>(null);
   const maskAnim = useAnimation();
+  const maskHasScrollbar =
+    isBrowser && hasScrollbar(html.querySelector('.Header-mask'));
 
   const btnRef = useRef<HTMLButtonElement | null>(null);
   const [btnFocus, setBtnFocus] = useState(false);
@@ -263,6 +265,7 @@ export const Header = ({ navTitle = CONTENT.defaultNavTitle }: HeaderProps) => {
     >
       <header
         className={c('Header', {
+          'has-scrollbar': maskHasScrollbar,
           'is-animating': animating,
           'is-open': maskOpen,
         })}

--- a/components/Header/Header.types.ts
+++ b/components/Header/Header.types.ts
@@ -5,14 +5,6 @@ export interface HeaderProps {
   navTitle?: string;
 }
 
-export interface HeaderMaskNavItemProps {
-  color: string;
-  href: URL['href'];
-  onClick: ComponentPropsWithoutRef<'a'>['onClick'];
-  title: string;
-  year: string | number;
-}
-
 export interface HeaderNavItemProps {
   href: URL['href'];
   isOpen: boolean;
@@ -21,3 +13,20 @@ export interface HeaderNavItemProps {
   target?: LinkRollProps['target'];
   title: string;
 }
+
+export interface HeaderMaskNavItemProps {
+  color: string;
+  href: URL['href'];
+  onClick: ComponentPropsWithoutRef<'a'>['onClick'];
+  title: string;
+  year: string | number;
+}
+
+export interface HeaderMaskNavItemSecondaryProps {
+  href: URL['href'];
+  onClick: ComponentPropsWithoutRef<'a'>['onClick'];
+  title: string;
+}
+
+export interface HeaderFooterNavItemProps
+  extends HeaderMaskNavItemSecondaryProps {}

--- a/components/Header/Header.types.ts
+++ b/components/Header/Header.types.ts
@@ -1,4 +1,5 @@
 import { type ComponentPropsWithoutRef } from 'react';
+import { type HTMLMotionProps } from 'framer-motion';
 import { type LinkRollProps } from '@/components/LinkRoll';
 
 export interface HeaderProps {
@@ -22,11 +23,15 @@ export interface HeaderMaskNavItemProps {
   year: string | number;
 }
 
-export interface HeaderMaskNavItemSecondaryProps {
+export interface HeaderMaskNavItemSecondaryProps
+  extends Pick<HTMLMotionProps<'li'>, 'custom'> {
   href: URL['href'];
   onClick: ComponentPropsWithoutRef<'a'>['onClick'];
   title: string;
 }
 
-export interface HeaderFooterNavItemProps
-  extends HeaderMaskNavItemSecondaryProps {}
+export interface HeaderFooterNavItemProps {
+  href: URL['href'];
+  onClick: ComponentPropsWithoutRef<'a'>['onClick'];
+  title: string;
+}

--- a/components/Header/HeaderFooterNavItem.tsx
+++ b/components/Header/HeaderFooterNavItem.tsx
@@ -1,0 +1,24 @@
+import { type HeaderFooterNavItemProps } from './';
+import { LinkRoll } from '@/components/LinkRoll';
+import { useUrlState } from '@/lib/useUrlState';
+
+export const HeaderFooterNavItem = ({
+  href,
+  onClick,
+  title,
+}: HeaderFooterNavItemProps) => {
+  const { active } = useUrlState(href);
+
+  return (
+    <li>
+      <LinkRoll
+        href={href}
+        onClick={onClick}
+        templateTransition={false}
+        underline={active}
+      >
+        {title}
+      </LinkRoll>
+    </li>
+  );
+};

--- a/components/Header/HeaderMaskNavItemSecondary.tsx
+++ b/components/Header/HeaderMaskNavItemSecondary.tsx
@@ -1,0 +1,30 @@
+import { type HeaderMaskNavItemSecondaryProps, maskNavItemVariant } from './';
+import { LinkRoll } from '@/components/LinkRoll';
+import { m } from 'framer-motion';
+import { useUrlState } from '@/lib/useUrlState';
+import c from 'clsx';
+
+export const HeaderMaskNavItemSecondary = ({
+  href,
+  onClick,
+  title,
+}: HeaderMaskNavItemSecondaryProps) => {
+  const { active } = useUrlState(href);
+  const classes = c('Header-mask-nav-secondary-item hidden@m', {
+    'is-active': active,
+  });
+
+  return (
+    <m.li className={classes} variants={maskNavItemVariant}>
+      <LinkRoll
+        className="Header-mask-nav-secondary-link h6 mb:0 wrap"
+        href={href}
+        onClick={onClick}
+        templateTransition={false}
+        underline={active}
+      >
+        {title}
+      </LinkRoll>
+    </m.li>
+  );
+};

--- a/components/Header/HeaderMaskNavItemSecondary.tsx
+++ b/components/Header/HeaderMaskNavItemSecondary.tsx
@@ -5,19 +5,20 @@ import { useUrlState } from '@/lib/useUrlState';
 import c from 'clsx';
 
 export const HeaderMaskNavItemSecondary = ({
+  custom,
   href,
   onClick,
   title,
 }: HeaderMaskNavItemSecondaryProps) => {
   const { active } = useUrlState(href);
-  const classes = c('Header-mask-nav-secondary-item hidden@m', {
+  const classes = c('Header-mask-nav-secondary-item wrap hidden@m', {
     'is-active': active,
   });
 
   return (
-    <m.li className={classes} variants={maskNavItemVariant}>
+    <m.li className={classes} custom={custom} variants={maskNavItemVariant}>
       <LinkRoll
-        className="Header-mask-nav-secondary-link h6 mb:0 wrap"
+        className="Header-mask-nav-secondary-link h6 mb:0"
         href={href}
         onClick={onClick}
         templateTransition={false}

--- a/components/Header/index.ts
+++ b/components/Header/index.ts
@@ -1,5 +1,7 @@
 export * from './Header';
 export * from './Header.animations';
 export * from './HeaderMaskNavItem';
+export * from './HeaderMaskNavItemSecondary';
 export * from './HeaderNavItem';
+export * from './HeaderFooterNavItem';
 export type * from './Header.types';

--- a/components/Info/Info.tsx
+++ b/components/Info/Info.tsx
@@ -54,25 +54,23 @@ export const Info = ({
               <Text className="mb:2xs" color="mute" size="s" tag="p">
                 Client
               </Text>
-              <Text size="s">
-                <p>
-                  <ConditionalWrapper
-                    condition={Boolean(href)}
-                    wrapper={children => (
-                      <Link href={href as URL['href']}>{children}</Link>
-                    )}
-                  >
-                    {name}
-                  </ConditionalWrapper>
-                </p>
+              <Text className="mb:0" size="s" tag="p">
+                <ConditionalWrapper
+                  condition={Boolean(href)}
+                  wrapper={children => (
+                    <Link href={href as URL['href']}>{children}</Link>
+                  )}
+                >
+                  {name}
+                </ConditionalWrapper>
               </Text>
             </div>
             <div className="grid-col grid-col:4@m grid-col:12@l">
               <Text className="mb:2xs" color="mute" size="s" tag="p">
                 Year
               </Text>
-              <Text size="s">
-                <p>{year}</p>
+              <Text className="mb:0" size="s" tag="p">
+                {year}
               </Text>
             </div>
             <div className="grid-col grid-col:4@m grid-col:12@l grid -gap-column:0">

--- a/components/Link/Link.tsx
+++ b/components/Link/Link.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, type HTMLMotionProps, m } from 'framer-motion';
 import { ConditionalWrapper } from '@/components/ConditionalWrapper';
+import { type ElementType, useState } from 'react';
 import {
   inVariant,
   inVariantX,
@@ -9,7 +10,6 @@ import {
 } from './';
 import { default as NextLink } from 'next/link';
 import { useApp } from '@/components/App';
-import { useState } from 'react';
 import { useUrlState } from '@/lib/useUrlState';
 import c from 'clsx';
 
@@ -33,7 +33,7 @@ export const Link = ({
     '-underline': underline,
     '-vertical': orientation === 'vertical',
   });
-  const Tag = tag ? m<HTMLMotionProps<typeof tag>>(tag) : m.a;
+  const Tag = tag ? (m[tag] as ElementType<HTMLMotionProps<typeof tag>>) : m.a;
   const { active, external, externalTarget } = useUrlState(href);
   const shouldNavigate =
     Boolean(href) && !external && target != '_blank' && target != '_new';

--- a/components/LinkRoll/LinkRoll.tsx
+++ b/components/LinkRoll/LinkRoll.tsx
@@ -6,10 +6,10 @@ import {
   linkVariants,
 } from './';
 import { ConditionalWrapper } from '@/components/ConditionalWrapper';
+import { type ElementType, useState } from 'react';
 import { isBoolean, isEmptyString } from '@/lib/utils';
 import { default as NextLink } from 'next/link';
 import { useApp } from '@/components/App';
-import { useState } from 'react';
 import { useUrlState } from '@/lib/useUrlState';
 import c from 'clsx';
 
@@ -31,7 +31,7 @@ export const LinkRoll = ({
     '-underline': underline,
     'has-underline': isBoolean(underline),
   });
-  const Tag = tag ? m<HTMLMotionProps<typeof tag>>(tag) : m.a;
+  const Tag = tag ? (m[tag] as ElementType<HTMLMotionProps<typeof tag>>) : m.a;
   const { active, external, externalTarget } = useUrlState(href);
   const shouldNavigate =
     Boolean(href) && !external && target != '_blank' && target != '_new';

--- a/components/LocomotiveScroll/LocomotiveScroll.tsx
+++ b/components/LocomotiveScroll/LocomotiveScroll.tsx
@@ -5,7 +5,7 @@ import {
   type LocomotiveScrollProviderProps,
   type ScrollProps,
 } from './';
-import useResizeObserver from 'use-resize-observer';
+import useResizeObserver, { type ObservedSize } from 'use-resize-observer';
 
 export const LocomotiveScrollContext =
   createContext<LocomotiveScrollContextProps>({
@@ -22,20 +22,16 @@ export const LocomotiveScrollProvider = ({
   options,
   watch,
 }: LocomotiveScrollProviderProps) => {
-  const { height: containerHeight } = useResizeObserver({ ref: containerRef });
   const [isReady, setIsReady] = useState(false);
   const LocomotiveScrollRef = useRef<ScrollProps | null>(null);
-  const [height, setHeight] = useState(containerHeight);
-
-  const handleResize = useMemo(
-    () => debounce((height: typeof containerHeight) => setHeight(height), 100),
-    [setHeight],
-  );
-
-  useEffect(
-    () => handleResize(containerHeight),
-    [containerHeight, handleResize],
-  );
+  const [{ height }, setSize] = useState<ObservedSize>({
+    height: undefined,
+    width: undefined,
+  });
+  useResizeObserver({
+    onResize: useMemo(() => debounce(setSize, 100), []),
+    ref: containerRef,
+  });
 
   useEffect(() => {
     (async () => {

--- a/components/Text/Text.tsx
+++ b/components/Text/Text.tsx
@@ -1,8 +1,8 @@
+import { type ElementType, useRef } from 'react';
 import { type HTMLMotionProps, m } from 'framer-motion';
 import { TEXT_VARIANTS } from '@/lib/config';
 import { type TextProps } from './';
 import { useInView } from '@/lib/useInView';
-import { useRef } from 'react';
 import c from 'clsx';
 
 export const Text = ({
@@ -33,7 +33,9 @@ export const Text = ({
   );
   const ref = useRef(null);
   const inView = useInView(ref);
-  const Tag = tag ? m<HTMLMotionProps<typeof tag>>(tag) : m.div;
+  const Tag = tag
+    ? (m[tag] as ElementType<HTMLMotionProps<typeof tag>>)
+    : m.div;
 
   return (
     <Tag

--- a/features/About/Intro.tsx
+++ b/features/About/Intro.tsx
@@ -137,7 +137,7 @@ export const AboutIntro = () => {
           />
         </div>
         <div className="grid-col grid-col:7@s -start:6@s grid-col:6@m grid-col:5@l -start:6@l">
-          <Text animate className="mb:m" tag="p">
+          <Text animate tag="p">
             I’m Joonas — UI/UX designer, front-end developer and sometimes even
             a <Link href={getLink('soundcloud').url}>music producer</Link>. I
             have a strong and great visual taste, broad understanding of
@@ -145,14 +145,14 @@ export const AboutIntro = () => {
             product and visual design, including web services, touch platforms
             and branding.
           </Text>
-          <Text animate className="mb:m" tag="p">
+          <Text animate tag="p">
             I get excited about finding unique and elegant solutions for complex
             user issues, and I love designing by code in the browser but I work
             a lot with <em>Figma</em> and other design tools as well. Usually I
             prefer writing applications with <em>TypeScript</em>, <em>React</em>
             , <em>Sass</em> and other modern tools.
           </Text>
-          <Text animate className="mb:m" tag="p">
+          <Text animate tag="p">
             With a background that spans both UI design and coding, I thrive at
             the intersection of aesthetics and functionality, blending the best
             of both worlds to deliver great user experiences.

--- a/features/About/Intro.tsx
+++ b/features/About/Intro.tsx
@@ -137,33 +137,25 @@ export const AboutIntro = () => {
           />
         </div>
         <div className="grid-col grid-col:7@s -start:6@s grid-col:6@m grid-col:5@l -start:6@l">
-          <Text animate className="mb:m">
-            <p>
-              I’m Joonas — UI/UX designer, front-end developer and sometimes
-              even a{' '}
-              <Link href={getLink('soundcloud').url}>music producer</Link>. I
-              have a strong and great visual taste, broad understanding of
-              front-end web technologies and a genuine passion for all aspects
-              of product and visual design, including web services, touch
-              platforms and branding.
-            </p>
+          <Text animate className="mb:m" tag="p">
+            I’m Joonas — UI/UX designer, front-end developer and sometimes even
+            a <Link href={getLink('soundcloud').url}>music producer</Link>. I
+            have a strong and great visual taste, broad understanding of
+            front-end web technologies and a genuine passion for all aspects of
+            product and visual design, including web services, touch platforms
+            and branding.
           </Text>
-          <Text animate className="mb:m">
-            <p>
-              I get excited about finding unique and elegant solutions for
-              complex user issues, and I love designing by code in the browser
-              but I work a lot with <em>Figma</em> and other design tools as
-              well. Usually I prefer writing applications with{' '}
-              <em>TypeScript</em>, <em>React</em>, <em>Sass</em> and other
-              modern tools.
-            </p>
+          <Text animate className="mb:m" tag="p">
+            I get excited about finding unique and elegant solutions for complex
+            user issues, and I love designing by code in the browser but I work
+            a lot with <em>Figma</em> and other design tools as well. Usually I
+            prefer writing applications with <em>TypeScript</em>, <em>React</em>
+            , <em>Sass</em> and other modern tools.
           </Text>
-          <Text animate className="mb:m">
-            <p>
-              With a background that spans both UI design and coding, I thrive
-              at the intersection of aesthetics and functionality, blending the
-              best of both worlds to deliver great user experiences.
-            </p>
+          <Text animate className="mb:m" tag="p">
+            With a background that spans both UI design and coding, I thrive at
+            the intersection of aesthetics and functionality, blending the best
+            of both worlds to deliver great user experiences.
           </Text>
           <Text animate className="mb:l">
             <Button href="/approach" icon={<ArrowRight />}>

--- a/features/Approach/Page.tsx
+++ b/features/Approach/Page.tsx
@@ -80,6 +80,7 @@ export const ApproachPage = ({ id, themeColor, title }: PageProps) => {
             </span>
             <Figure
               alt="Joonas Sandell"
+              animate={false}
               className="Template-profileMobile hidden@l"
               scrollPosition="top"
               sizes="25vw"
@@ -93,56 +94,45 @@ export const ApproachPage = ({ id, themeColor, title }: PageProps) => {
         </TemplateSection>
         <TemplateSection gridRowGap={false} pb="10vw" pt="l">
           <div className="grid-col grid-col:6@m grid-col:4@l">
-            <Text animate className="mb:m">
-              <p>
-                In my approach to design, I generally prioritise adherence to UI
-                conventions while infusing subtle, unique elements that enhance
-                user engagement. I firmly believe that good design should be
-                intuitive and seamless, striving for invisibility while ensuring
-                that every interaction feels polished and refined.
-              </p>
+            <Text animate tag="p">
+              In my approach to design, I generally prioritise adherence to UI
+              conventions while infusing subtle, unique elements that enhance
+              user engagement. I firmly believe that good design should be
+              intuitive and seamless, striving for invisibility while ensuring
+              that every interaction feels polished and refined.
             </Text>
-            <Text animate className="mb:m">
-              <p>
-                <em>“Good design is invisible”</em> like some say and I believe
-                that’s a good mindset to have when building a successful
-                product.
-              </p>
+            <Text animate tag="p">
+              <em>“Good design is invisible”</em> like some say and I believe
+              that’s a good mindset to have when building a successful product.
             </Text>
-            <Text animate className="mb:m">
-              <p>
-                In designing interfaces and end-to-end websites, I consider a
-                multitude of factors, including accessibility, UX principles,
-                target group, value for end users, consistency, conversion rate
-                and business logic. While I recognise the importance of
-                aesthetics, I firmly believe that data-driven content reigns
-                supreme, collaborating closely with copywriters and marketing
-                team to ensure that messaging is concise and impactful without
-                compromising visual appeal.
-              </p>
+            <Text animate tag="p">
+              In designing interfaces and end-to-end websites, I consider a
+              multitude of factors, including accessibility, UX principles,
+              target group, value for end users, consistency, conversion rate
+              and business logic. While I recognise the importance of
+              aesthetics, I firmly believe that data-driven content reigns
+              supreme, collaborating closely with copywriters and marketing team
+              to ensure that messaging is concise and impactful without
+              compromising visual appeal.
             </Text>
           </div>
           <div className="grid-col grid-col:6@m grid-col:4@l">
-            <Text animate className="mb:m">
-              <p>
-                When it comes to coding, I adhere to best practices, writing
-                clean, maintainable code with meaningful variable names and
-                thorough documentation. I prioritise simplicity over complexity,
-                actively seeking to streamline solutions and avoid shortcuts or
-                hacks whenever possible.
-              </p>
+            <Text animate tag="p">
+              When it comes to coding, I adhere to best practices, writing
+              clean, maintainable code with meaningful variable names and
+              thorough documentation. I prioritise simplicity over complexity,
+              actively seeking to streamline solutions and avoid shortcuts or
+              hacks whenever possible.
             </Text>
-            <Text animate className="mb:m">
-              <p>
-                I’m both systematic and adaptive in my approach, valuing
-                organization and adherence to project guidelines while remaining
-                flexible enough to accommodate evolving requirements. For me,
-                the DX is paramount, and I am dedicated to fostering an
-                environment where everyone can contribute effectively to
-                building exceptional products.
-              </p>
+            <Text animate tag="p">
+              I’m both systematic and adaptive in my approach, valuing
+              organization and adherence to project guidelines while remaining
+              flexible enough to accommodate evolving requirements. For me, the
+              DX is paramount, and I am dedicated to fostering an environment
+              where everyone can contribute effectively to building exceptional
+              products.
             </Text>
-            <Text animate className="mb:m">
+            <Text animate>
               <p>
                 To put it simply, for me, it’s both how it works and how it
                 looks.

--- a/features/Resume/Content.tsx
+++ b/features/Resume/Content.tsx
@@ -42,7 +42,7 @@ export const Content = () => (
     </Text>
     <Button
       className="mb:xl"
-      href="/Joonas-Sandell-CV.pdf"
+      href="/cv"
       icon={<Download />}
       target="_blank"
       variant="negative"
@@ -71,7 +71,7 @@ export const Content = () => (
           </Link>
         </Heading>
         <Text color="mute" tag="p">
-          Nov 2020 — Present
+          Nov 2020 – Present
         </Text>
         <Text maxWidth>
           <ul className="pl">
@@ -91,14 +91,14 @@ export const Content = () => (
               product and suggesting user-centric features based on analytics
             </li>
             <li>
-              Developed and built{' '}
+              Developed and designed{' '}
               <Link href={getSitemap('biocode').url}>Biocode</Link>’s end-to-end{' '}
               <Link href="https://biocode.io">website</Link> including
               dark/light modes, CMS and <em>Hubspot</em> integration among many
               other features
             </li>
             <li>
-              Designed, developed and authored{' '}
+              Authored, designed and developed{' '}
               <em>
                 <Link href="https://github.com/joonassandell/bds">
                   Biocode Design System
@@ -108,7 +108,7 @@ export const Content = () => (
               packaging stamps
             </li>
             <li>
-              Designed and built headless{' '}
+              Designed and developed headless{' '}
               <em>
                 <Link href="https://report.biocode.io">
                   Biocode for reporting
@@ -145,7 +145,7 @@ export const Content = () => (
           </Link>
         </Heading>
         <Text color="mute" tag="p">
-          Sep 2014 — Nov 2020
+          Sep 2014 – Nov 2020
         </Text>
         <Text maxWidth>
           <ul className="pl">
@@ -170,7 +170,7 @@ export const Content = () => (
               </em>
             </li>
             <li>
-              Developed and designed websites, e-commerce stores and web
+              Designed and developed websites, e-commerce stores and web
               services for clients such as{' '}
               <em>
                 <Link
@@ -207,7 +207,7 @@ export const Content = () => (
               design and website renewal
             </li>
             <li>
-              Designed and built internal products such as{' '}
+              Developed and designed internal products such as{' '}
               <em>
                 <Link href={`${getSitemap('more-work').url}/#rubik`}>
                   Rubik
@@ -240,7 +240,7 @@ export const Content = () => (
           UI/UX designer, Front-end developer — City of Tampere
         </Heading>
         <Text color="mute" tag="p">
-          Apr 2007 — Sep 2014
+          Apr 2007 – Sep 2014
         </Text>
         <Text maxWidth>
           <ul className="pl">

--- a/features/Resume/Content.tsx
+++ b/features/Resume/Content.tsx
@@ -217,8 +217,11 @@ export const Content = () => (
               variety of customers
             </li>
             <li>
-              Crafted and documented internal tools to quickly kick-start
-              projects
+              Crafted and documented{' '}
+              <Link href="https://github.com/joonassandell/rebirth">
+                internal tools
+              </Link>{' '}
+              to quickly kick-start projects
             </li>
             <li>
               Managed to acquire new clients based on past experience, outside

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -29,18 +29,18 @@ export const SITEMAP: Sitemap = {
       url: '/approach',
     },
     {
-      id: 'contact',
-      navTitle: 'Contact',
-      themeColor: '#c1c0b6',
-      title: 'Contact',
-      url: '/contact',
-    },
-    {
       hidden: true,
       id: 'resume',
       navTitle: 'Resume',
       title: 'Resume',
       url: '/resume',
+    },
+    {
+      id: 'contact',
+      navTitle: 'Contact',
+      themeColor: '#c1c0b6',
+      title: 'Contact',
+      url: '/contact',
     },
     {
       hidden: true,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -94,3 +94,8 @@ export const stripUrl = (url: string) => {
   const pattern = /^(https?:\/\/)?(www\.)?/;
   return url.replace(pattern, '');
 };
+
+export const hasScrollbar = (el: HTMLElement | null) => {
+  if (!el) return false;
+  return el.scrollHeight > el.clientHeight || el.scrollWidth > el.clientWidth;
+};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -56,6 +56,15 @@ const config = {
       },
     ];
   },
+  async redirects() {
+    return [
+      {
+        source: '/cv',
+        destination: '/Joonas-Sandell-CV.pdf',
+        permanent: false,
+      },
+    ];
+  },
 };
 
 export default withBundleAnalyzer(config);

--- a/stylesheets/tokens.scss
+++ b/stylesheets/tokens.scss
@@ -87,6 +87,7 @@
 
   // Text
   --text-50: var(--white);
+  --text-100: var(--gray-400);
   --text-800-blend: hsl(var(--white-hsl) / 0.6);
   --text-800: var(--gray-600);
   --text-900: var(--gray-900);

--- a/stylesheets/utils/scrollbar.scss
+++ b/stylesheets/utils/scrollbar.scss
@@ -4,7 +4,7 @@
 .scrollbar {
   -webkit-overflow-scrolling: touch;
   -ms-overflow-style: -ms-autohiding-scrollbar;
-  overflow-y: auto;
+  overflow-y: var(--scrollbar-overflow, auto);
   overscroll-behavior: contain;
   scrollbar-color: var(--scrollbar-thumb) transparent;
   scrollbar-width: thin;


### PR DESCRIPTION
# New header navigation and content

Add new navigation especially for mobile so that all the subpages are easily available just like in footer. Also add social icons instead of links and add link to latest the update.

## Extras

- Header: Fix possible scrollbar jump
- LocomotiveScroll:  Debounce properly. Previous solution caused loads of rerenders on window resize.
- Text/Link/LinkRoll: Change the way custom tag was assigned. Using the `m` (motion) component created unnecessary rerenders. Don't know why.
- Update/redirect CV
- Various content tweaks and fixes